### PR TITLE
fix: increase update interval to 240s

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ wilson version             Show Wilson + all service versions
 Wilson owns deployment for all services. Each service owns its own code,
 CI, and install script. Wilson provides:
 
-- A LaunchAgent that checks for updates every 60 seconds
+- A LaunchAgent that checks for updates every 4 minutes
 - A CLI for monitoring and managing all services from one place
 - Update orchestration: version check → delegate to service installer → restart
 
 ### Update flow
 
 ```
-wilson-update.sh (runs every 60s via LaunchAgent)
+wilson-update.sh (runs every 4min via LaunchAgent)
 ├── 1. Check Engram for updates → if newer: run engram install.sh, restart
 ├── 2. Check Synapse for updates → if newer: run synapse install.sh, restart
 └── 3. Check Wilson for updates → if newer: run wilson install.sh (self-update)

--- a/deploy/plists/com.suyash.wilson-updater.plist
+++ b/deploy/plists/com.suyash.wilson-updater.plist
@@ -22,7 +22,7 @@
   </dict>
 
   <key>StartInterval</key>
-  <integer>60</integer>
+  <integer>240</integer>
 
   <key>StandardOutPath</key>
   <string>${HOME}/Library/Logs/wilson-updater.log</string>

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -160,7 +160,7 @@ install_launch_agent() {
       warn "Could not load LaunchAgent. Load it manually:"
       warn "  launchctl bootstrap gui/${uid} ${plist_dest}"
     }
-    ok "LaunchAgent loaded (updates every 60s)"
+    ok "LaunchAgent loaded (updates every 4min)"
   else
     warn "LaunchAgent plist not found in release, skipping"
   fi


### PR DESCRIPTION
## Summary
- Increase LaunchAgent update interval from 60s to 240s (4 minutes)
- 60s interval with 3 services = 180 GitHub API calls/hr, exceeding the 60/hr unauthenticated rate limit
- 240s = 45 calls/hr, safely within the limit with 25% headroom