### PR TITLE
fix: prevent updater self-update launchctl race

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -152,15 +152,19 @@ install_launch_agent() {
     sed "s|\${HOME}|${HOME}|g" "$plist_template" > "$plist_dest"
     ok "LaunchAgent installed: ${plist_dest}"
 
-    # Load the agent (unload first if already loaded)
-    local uid
-    uid=$(id -u)
-    launchctl bootout "gui/${uid}/com.suyash.wilson-updater" 2>/dev/null || true
-    launchctl bootstrap "gui/${uid}" "$plist_dest" 2>/dev/null || {
-      warn "Could not load LaunchAgent. Load it manually:"
-      warn "  launchctl bootstrap gui/${uid} ${plist_dest}"
-    }
-    ok "LaunchAgent loaded (updates every 4min)"
+    if [ "${SKIP_LAUNCHAGENT_RELOAD:-0}" = "1" ]; then
+      warn "Skipping LaunchAgent reload (managed by updater)"
+    else
+      # Load the agent (unload first if already loaded)
+      local uid
+      uid=$(id -u)
+      launchctl bootout "gui/${uid}/com.suyash.wilson-updater" 2>/dev/null || true
+      launchctl bootstrap "gui/${uid}" "$plist_dest" 2>/dev/null || {
+        warn "Could not load LaunchAgent. Load it manually:"
+        warn "  launchctl bootstrap gui/${uid} ${plist_dest}"
+      }
+      ok "LaunchAgent loaded (updates every 4min)"
+    fi
   else
     warn "LaunchAgent plist not found in release, skipping"
   fi


### PR DESCRIPTION
## Summary
- avoid killing `wilson-update.sh` during Wilson self-updates by passing `SKIP_LAUNCHAGENT_RELOAD=1` to the installer
- add async LaunchAgent reload + verification after Wilson self-update completes
- add startup recovery check to bootstrap the updater agent if it is found unloaded

## Why
When Wilson updates itself, the installer's synchronous `launchctl bootout` can terminate the currently running updater process before the update flow completes. This change moves reload handling into the updater with deferred execution so self-updates remain reliable and self-healing.

## Validation
- `bash -n scripts/install.sh`
- `bash -n deploy/wilson-update.sh`