### PR TITLE
feat: register cortex as managed service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Wilson
 
 Deployment orchestration for the Wilson system. Manages updates and monitoring
-for Engram, Synapse, and itself on the Mac Mini.
+for Engram, Synapse, Cortex, and itself on the Mac Mini.
 
 ## Install
 
@@ -24,6 +24,7 @@ wilson version             Show Wilson + all service versions
 
 - `engram` — Engram daemon log
 - `synapse` — Synapse daemon log
+- `cortex` — Cortex daemon log
 - `updater` — Wilson update orchestrator log
 
 ### Options
@@ -45,7 +46,8 @@ CI, and install script. Wilson provides:
 wilson-update.sh (runs every 4min via LaunchAgent)
 ├── 1. Check Engram for updates → if newer: run engram install.sh, restart
 ├── 2. Check Synapse for updates → if newer: run synapse install.sh, restart
-└── 3. Check Wilson for updates → if newer: run wilson install.sh (self-update)
+├── 3. Check Cortex for updates → if newer: run cortex install.sh, restart
+└── 4. Check Wilson for updates → if newer: run wilson install.sh (self-update)
 ```
 
 Each check is independent — failure in one does not block the others.
@@ -56,6 +58,7 @@ Each check is independent — failure in one does not block the others.
 |---------|------|------|---------|
 | Engram  | shetty4l/engram  | 7749 | Persistent memory |
 | Synapse | shetty4l/synapse | 7750 | LLM routing proxy |
+| Cortex  | shetty4l/cortex  | 7751 | Life assistant |
 
 ## Paths
 
@@ -64,9 +67,11 @@ Each check is independent — failure in one does not block the others.
 | `~/srv/wilson/` | Wilson install (versioned dirs + `latest` symlink) |
 | `~/srv/engram/` | Engram install |
 | `~/srv/synapse/` | Synapse install |
+| `~/srv/cortex/` | Cortex install |
 | `~/.local/bin/wilson` | Wilson CLI |
 | `~/.local/bin/engram` | Engram CLI |
 | `~/.local/bin/synapse` | Synapse CLI |
+| `~/.local/bin/cortex` | Cortex CLI |
 | `~/Library/LaunchAgents/com.suyash.wilson-updater.plist` | Update LaunchAgent |
 | `~/Library/Logs/wilson-updater.log` | Update orchestrator log |
 

--- a/deploy/wilson-update.sh
+++ b/deploy/wilson-update.sh
@@ -8,7 +8,8 @@ set -uo pipefail
 # Services are checked in dependency order:
 #   1. engram (dependency of other services)
 #   2. synapse (model routing)
-#   3. wilson (self — last, since we're running from wilson's scripts)
+#   3. cortex (life assistant — depends on engram + synapse)
+#   4. wilson (self — last, since we're running from wilson's scripts)
 #
 # Each service's install.sh handles the heavy lifting (download, extract,
 # install deps, symlink). This script only does version comparison and
@@ -126,6 +127,10 @@ case "$TARGET" in
     log "INFO: update check starting (synapse only)"
     check_and_update "synapse" "shetty4l/synapse" || (( failures++ ))
     ;;
+  cortex)
+    log "INFO: update check starting (cortex only)"
+    check_and_update "cortex" "shetty4l/cortex" || (( failures++ ))
+    ;;
   self)
     log "INFO: update check starting (wilson self)"
     check_and_update_self || (( failures++ ))
@@ -135,10 +140,11 @@ case "$TARGET" in
     # Each check is independent — failure in one does not block the others
     check_and_update "engram"  "shetty4l/engram"  || (( failures++ ))
     check_and_update "synapse" "shetty4l/synapse" || (( failures++ ))
+    check_and_update "cortex"  "shetty4l/cortex"  || (( failures++ ))
     check_and_update_self                          || (( failures++ ))
     ;;
   *)
-    echo "Usage: wilson-update.sh [engram|synapse|self|all]" >&2
+    echo "Usage: wilson-update.sh [engram|synapse|cortex|self|all]" >&2
     exit 1
     ;;
 esac

--- a/src/services.ts
+++ b/src/services.ts
@@ -26,7 +26,7 @@ export const SERVICES: readonly ServiceConfig[] = [
     currentVersionFile: join(HOME, "srv", "engram", "current-version"),
     cliPath: join(HOME, ".local", "bin", "engram"),
     logFiles: {
-      daemon: join(HOME, ".local", "share", "engram", "engram.log"),
+      daemon: join(HOME, ".config", "engram", "engram.log"),
       updater: join(HOME, "Library", "Logs", "wilson-updater.log"),
     },
   },
@@ -41,6 +41,20 @@ export const SERVICES: readonly ServiceConfig[] = [
     cliPath: join(HOME, ".local", "bin", "synapse"),
     logFiles: {
       daemon: join(HOME, ".config", "synapse", "synapse.log"),
+      updater: join(HOME, "Library", "Logs", "wilson-updater.log"),
+    },
+  },
+  {
+    name: "cortex",
+    displayName: "Cortex",
+    repo: "shetty4l/cortex",
+    port: 7751,
+    healthUrl: "http://localhost:7751/health",
+    installBase: join(HOME, "srv", "cortex"),
+    currentVersionFile: join(HOME, "srv", "cortex", "current-version"),
+    cliPath: join(HOME, ".local", "bin", "cortex"),
+    logFiles: {
+      daemon: join(HOME, ".config", "cortex", "cortex.log"),
       updater: join(HOME, "Library", "Logs", "wilson-updater.log"),
     },
   },

--- a/test/services.test.ts
+++ b/test/services.test.ts
@@ -13,7 +13,7 @@ const HOME = homedir();
 
 describe("service registry", () => {
   test("has expected number of services", () => {
-    expect(SERVICES.length).toBe(2);
+    expect(SERVICES.length).toBe(3);
   });
 
   test("each service has all required fields", () => {
@@ -37,6 +37,13 @@ describe("service registry", () => {
     expect(engram!.repo).toBe("shetty4l/engram");
   });
 
+  test("getService returns correct cortex config", () => {
+    const cortex = getService("cortex");
+    expect(cortex).toBeDefined();
+    expect(cortex!.port).toBe(7751);
+    expect(cortex!.repo).toBe("shetty4l/cortex");
+  });
+
   test("getService returns undefined for unknown", () => {
     expect(getService("unknown")).toBeUndefined();
   });
@@ -45,13 +52,15 @@ describe("service registry", () => {
     const names = getServiceNames();
     expect(names).toContain("engram");
     expect(names).toContain("synapse");
-    expect(names.length).toBe(2);
+    expect(names).toContain("cortex");
+    expect(names.length).toBe(3);
   });
 
   test("getLogSources includes services and updater", () => {
     const sources = getLogSources();
     expect(sources).toContain("engram");
     expect(sources).toContain("synapse");
+    expect(sources).toContain("cortex");
     expect(sources).toContain("updater");
   });
 


### PR DESCRIPTION
## Summary
- Add Cortex (port 7751, `shetty4l/cortex`) to the Wilson service registry
- Add cortex to update script with correct dependency order: engram -> synapse -> cortex -> wilson self
- Update engram log path to `~/.config/engram/engram.log` to match standardized convention (companion to shetty4l/engram PR)
- Update tests (2 -> 3 services) and README documentation

## What auto-propagates
All Wilson commands (`status`, `health`, `logs`, `restart`, `update`, `version`) automatically pick up cortex via SERVICES array iteration.