### PR TITLE
fix: add AbandonProcessGroup to LaunchAgent plist

### DIFF
--- a/deploy/plists/com.suyash.wilson-updater.plist
+++ b/deploy/plists/com.suyash.wilson-updater.plist
@@ -24,6 +24,12 @@
   <key>StartInterval</key>
   <integer>240</integer>
 
+  <!-- Allow spawned service daemons to survive after the update script exits.
+       Without this, launchd sends SIGTERM to the entire process group on exit,
+       killing freshly-started engram/synapse/cortex daemons. -->
+  <key>AbandonProcessGroup</key>
+  <true/>
+
   <key>StandardOutPath</key>
   <string>${HOME}/Library/Logs/wilson-updater.log</string>
   <key>StandardErrorPath</key>


### PR DESCRIPTION
## Summary
- Adds `AbandonProcessGroup = true` to the wilson-updater LaunchAgent plist

## Problem
When `wilson-update.sh` exits after updating services, launchd sends SIGTERM to the entire process group — killing freshly-started engram/synapse/cortex daemons that were spawned via `<service> restart` during the update cycle.

Services would start, pass health checks, then die seconds later when the update script completed.

## Root Cause
launchd's default behavior is to kill all child processes when a scheduled job exits. The prior bootout fix (a37515b) addressed self-update reloads but missed this fundamental process group cleanup behavior.

## Fix
`AbandonProcessGroup = true` tells launchd to leave child processes alone when the job exits.

Already applied to the live mac-mini plist and reloaded.