### PR TITLE
ci: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "deps"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` for automated weekly dependency updates
- Covers **npm** packages and **GitHub Actions** versions
- Commit prefixes: `deps:` for npm, `ci:` for actions