### PR TITLE
refactor: adopt Result type for expected error handling

### DIFF
--- a/src/restart.ts
+++ b/src/restart.ts
@@ -13,12 +13,14 @@ export async function cmdRestart(
     return 1;
   }
 
-  const svc = getService(serviceName);
-  if (!svc) {
-    console.error(`Error: unknown service "${serviceName}"`);
+  const result = getService(serviceName);
+  if (!result.ok) {
+    console.error(`Error: ${result.error}`);
     console.error(`Services: ${getServiceNames().join(", ")}`);
     return 1;
   }
+
+  const svc = result.value;
 
   if (!existsSync(svc.cliPath)) {
     if (json) {

--- a/src/services.ts
+++ b/src/services.ts
@@ -1,3 +1,4 @@
+import { err, ok, type Result } from "@shetty4l/core/result";
 import { homedir } from "os";
 import { join } from "path";
 
@@ -76,8 +77,10 @@ export const WILSON_CONFIG = {
   },
 } as const;
 
-export function getService(name: string): ServiceConfig | undefined {
-  return SERVICES.find((s) => s.name === name);
+export function getService(name: string): Result<ServiceConfig, string> {
+  const svc = SERVICES.find((s) => s.name === name);
+  if (!svc) return err(`unknown service "${name}"`);
+  return ok(svc);
 }
 
 export function getServiceNames(): string[] {

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,7 +1,10 @@
 import { join } from "path";
 import { getService, getServiceNames } from "./services";
 
-export async function cmdUpdate(args: string[], json: boolean): Promise<void> {
+export async function cmdUpdate(
+  args: string[],
+  json: boolean,
+): Promise<number> {
   const serviceName = args[0];
 
   // Resolve the update script path relative to this repo
@@ -10,10 +13,13 @@ export async function cmdUpdate(args: string[], json: boolean): Promise<void> {
 
   if (serviceName) {
     // Validate service name
-    if (serviceName !== "self" && !getService(serviceName)) {
-      console.error(`Error: unknown service "${serviceName}"`);
-      console.error(`Services: ${getServiceNames().join(", ")}, self`);
-      process.exit(1);
+    if (serviceName !== "self") {
+      const svcResult = getService(serviceName);
+      if (!svcResult.ok) {
+        console.error(`Error: ${svcResult.error}`);
+        console.error(`Services: ${getServiceNames().join(", ")}, self`);
+        return 1;
+      }
     }
 
     if (!json) {
@@ -39,10 +45,7 @@ export async function cmdUpdate(args: string[], json: boolean): Promise<void> {
       );
     }
 
-    if (exitCode !== 0) {
-      process.exit(exitCode);
-    }
-    return;
+    return exitCode;
   }
 
   // Run full update check
@@ -65,7 +68,5 @@ export async function cmdUpdate(args: string[], json: boolean): Promise<void> {
     );
   }
 
-  if (exitCode !== 0) {
-    process.exit(exitCode);
-  }
+  return exitCode;
 }

--- a/test/services.test.ts
+++ b/test/services.test.ts
@@ -31,21 +31,26 @@ describe("service registry", () => {
   });
 
   test("getService returns correct service", () => {
-    const engram = getService("engram");
-    expect(engram).toBeDefined();
-    expect(engram!.port).toBe(7749);
-    expect(engram!.repo).toBe("shetty4l/engram");
+    const result = getService("engram");
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.value.port).toBe(7749);
+    expect(result.value.repo).toBe("shetty4l/engram");
   });
 
   test("getService returns correct cortex config", () => {
-    const cortex = getService("cortex");
-    expect(cortex).toBeDefined();
-    expect(cortex!.port).toBe(7751);
-    expect(cortex!.repo).toBe("shetty4l/cortex");
+    const result = getService("cortex");
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.value.port).toBe(7751);
+    expect(result.value.repo).toBe("shetty4l/cortex");
   });
 
-  test("getService returns undefined for unknown", () => {
-    expect(getService("unknown")).toBeUndefined();
+  test("getService returns err for unknown", () => {
+    const result = getService("unknown");
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected err");
+    expect(result.error).toBe('unknown service "unknown"');
   });
 
   test("getServiceNames returns all names", () => {


### PR DESCRIPTION
## Summary
- `getService()` returns `Result<ServiceConfig>` instead of `undefined` — centralizes error message, eliminates 3 duplicate null-checks
- `readLastLines()` returns `Result<string[]>` distinguishing file-not-found, tail-failure, and empty-file
- `checkService`/`checkHealth` extract `fetchHealth()` returning `Result<HealthResponse>` with specific error details (timeout, connection refused) instead of generic "not reachable"
- Eliminate `process.exit(1)` from `cmdLogs`/`cmdUpdate`, return exit codes consistently like `cmdRestart`

## Changes
| File | Change |
|------|--------|
| `src/services.ts` | `getService()` → `Result<ServiceConfig, string>` |
| `src/logs.ts` | `readLastLines()` → `Result<string[]>`, `cmdLogs` returns exit codes |
| `src/status.ts` | Extract `fetchHealth()` → `Result<HealthResponse>` |
| `src/health.ts` | Extract `fetchHealth()` → `Result<HealthResponse>`, display shows actual error reason |
| `src/restart.ts` | Consume `Result` from `getService()` |
| `src/update.ts` | Consume `Result` from `getService()`, return exit codes |
| `test/services.test.ts` | Adapted for Result semantics |

## Testing
- `bun run validate` passes clean (typecheck + oxlint + biome + 14 tests, 62 assertions)
- No behavior changes for success paths
- Error paths now show specific failure reasons instead of generic messages