### PR TITLE
refactor: unify wilson as first-class service in wilson-ctl

### DIFF
--- a/src/ctl-cli.ts
+++ b/src/ctl-cli.ts
@@ -21,7 +21,7 @@ Usage:
   wilson-ctl version              Show version
 
 Services: ${getServiceNames().join(", ")}
-Log sources: ${getServiceNames().join(", ")}, updater, wilson
+Log sources: ${getServiceNames().join(", ")}, updater
 
 Options:
   --json                Machine-readable JSON output

--- a/src/logs.ts
+++ b/src/logs.ts
@@ -1,10 +1,5 @@
 import { createLogsCommand } from "@shetty4l/core/cli";
-import {
-  getLogSources,
-  getService,
-  UPDATER_LOG,
-  WILSON_CONFIG,
-} from "./services";
+import { getLogSources, getService, UPDATER_LOG } from "./services";
 
 /**
  * Wilson logs command — takes a <source> argument (service name or "updater")
@@ -25,8 +20,6 @@ export async function cmdLogs(args: string[], json: boolean): Promise<number> {
 
   if (source === "updater") {
     logFile = UPDATER_LOG;
-  } else if (source === "wilson") {
-    logFile = WILSON_CONFIG.logFiles.daemon;
   } else {
     const svcResult = getService(source);
     if (!svcResult.ok) {

--- a/src/services.ts
+++ b/src/services.ts
@@ -64,24 +64,23 @@ export const SERVICES: readonly ServiceConfig[] = [
       daemon: join(getConfigDir("cortex"), "cortex.log"),
     },
   },
+  {
+    name: "wilson",
+    displayName: "Wilson",
+    repo: "shetty4l/wilson",
+    port: 7748,
+    healthUrl: "http://localhost:7748/health",
+    installBase: join(HOME, "srv", "wilson"),
+    configDir: getConfigDir("wilson"),
+    currentVersionFile: join(HOME, "srv", "wilson", "current-version"),
+    cliPath: join(HOME, ".local", "bin", "wilson"),
+    logFiles: {
+      daemon: join(getConfigDir("wilson"), "wilson.log"),
+    },
+  },
 ] as const;
 
 export const UPDATER_LOG = join(HOME, "Library", "Logs", "wilson-updater.log");
-
-export const WILSON_CONFIG = {
-  name: "wilson",
-  displayName: "Wilson",
-  repo: "shetty4l/wilson",
-  port: 7748,
-  healthUrl: "http://localhost:7748/health",
-  installBase: join(HOME, "srv", "wilson"),
-  configDir: getConfigDir("wilson"),
-  currentVersionFile: join(HOME, "srv", "wilson", "current-version"),
-  cliPath: join(HOME, ".local", "bin", "wilson"),
-  logFiles: {
-    daemon: join(getConfigDir("wilson"), "wilson.log"),
-  },
-} as const;
 
 export function getService(name: string): Result<ServiceConfig, string> {
   const svc = SERVICES.find((s) => s.name === name);
@@ -98,5 +97,5 @@ export function getServiceNames(): string[] {
  * Includes each service name + "updater" for the wilson update log.
  */
 export function getLogSources(): string[] {
-  return [...getServiceNames(), "updater", "wilson"];
+  return [...getServiceNames(), "updater"];
 }

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,8 +1,7 @@
 import { err, ok, type Result } from "@shetty4l/core/result";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
-import { SERVICES, WILSON_CONFIG } from "./services";
-import { VERSION } from "./version";
+import { SERVICES } from "./services";
 
 interface HealthResponse {
   status?: string;
@@ -11,7 +10,7 @@ interface HealthResponse {
 
 interface ServiceStatus {
   name: string;
-  status: "running" | "stopped" | "unreachable" | "ok";
+  status: "running" | "stopped" | "unreachable";
   version: string;
   port: number | null;
   pid: number | null;
@@ -83,22 +82,6 @@ export async function cmdStatus(json: boolean): Promise<void> {
   const results: ServiceStatus[] = await Promise.all(
     SERVICES.map(checkService),
   );
-
-  // Add Wilson itself
-  let wilsonVersion = VERSION;
-  if (existsSync(WILSON_CONFIG.currentVersionFile)) {
-    wilsonVersion = readFileSync(
-      WILSON_CONFIG.currentVersionFile,
-      "utf-8",
-    ).trim();
-  }
-  results.push({
-    name: "wilson",
-    status: "ok",
-    version: wilsonVersion,
-    port: null,
-    pid: null,
-  });
 
   if (json) {
     console.log(JSON.stringify(results, null, 2));

--- a/src/update.ts
+++ b/src/update.ts
@@ -13,13 +13,11 @@ export async function cmdUpdate(
 
   if (serviceName) {
     // Validate service name
-    if (serviceName !== "self") {
-      const svcResult = getService(serviceName);
-      if (!svcResult.ok) {
-        console.error(`Error: ${svcResult.error}`);
-        console.error(`Services: ${getServiceNames().join(", ")}, self`);
-        return 1;
-      }
+    const svcResult = getService(serviceName);
+    if (!svcResult.ok) {
+      console.error(`Error: ${svcResult.error}`);
+      console.error(`Services: ${getServiceNames().join(", ")}`);
+      return 1;
     }
 
     if (!json) {

--- a/test/services.test.ts
+++ b/test/services.test.ts
@@ -6,14 +6,13 @@ import {
   getService,
   getServiceNames,
   SERVICES,
-  WILSON_CONFIG,
 } from "../src/services";
 
 const HOME = homedir();
 
 describe("service registry", () => {
   test("has expected number of services", () => {
-    expect(SERVICES.length).toBe(3);
+    expect(SERVICES.length).toBe(4);
   });
 
   test("each service has all required fields", () => {
@@ -58,21 +57,28 @@ describe("service registry", () => {
     expect(names).toContain("engram");
     expect(names).toContain("synapse");
     expect(names).toContain("cortex");
-    expect(names.length).toBe(3);
+    expect(names).toContain("wilson");
+    expect(names.length).toBe(4);
   });
 
-  test("getLogSources includes services, updater, and wilson", () => {
+  test("getLogSources includes services and updater", () => {
     const sources = getLogSources();
     expect(sources).toContain("engram");
     expect(sources).toContain("synapse");
     expect(sources).toContain("cortex");
-    expect(sources).toContain("updater");
     expect(sources).toContain("wilson");
+    expect(sources).toContain("updater");
+    expect(sources.length).toBe(5);
   });
 
-  test("wilson config has correct paths", () => {
-    expect(WILSON_CONFIG.repo).toBe("shetty4l/wilson");
-    expect(WILSON_CONFIG.installBase).toBe(join(HOME, "srv", "wilson"));
-    expect(WILSON_CONFIG.cliPath).toBe(join(HOME, ".local", "bin", "wilson"));
+  test("getService returns correct wilson config", () => {
+    const result = getService("wilson");
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.value.port).toBe(7748);
+    expect(result.value.repo).toBe("shetty4l/wilson");
+    expect(result.value.installBase).toBe(join(HOME, "srv", "wilson"));
+    expect(result.value.cliPath).toBe(join(HOME, ".local", "bin", "wilson"));
+    expect(result.value.healthUrl).toBe("http://localhost:7748/health");
   });
 });


### PR DESCRIPTION
## Summary
- Add wilson to `SERVICES[]` array (port 7748, healthUrl, cliPath, logFiles)
- Remove `WILSON_CONFIG` export entirely
- `wilson-ctl status` now shows wilson with real PID/port/health (was hardcoded ok/null/null)
- `wilson-ctl health` now includes wilson
- `wilson-ctl restart wilson` works (was: unknown service)
- `wilson-ctl update wilson` works (was: must use `self`)
- `wilson-ctl logs wilson` goes through normal path (was: special-cased)
- `deploy/wilson-update.sh`: merged `check_and_update_self()` into `check_and_update()`
- Removed `self` keyword entirely

## Breaking Changes
- `wilson-ctl update self` no longer works — use `wilson-ctl update wilson`

## Acceptance Criteria
1. ✅ SERVICES has 4 entries
2. ✅ getService("wilson") works
3. ✅ getServiceNames() returns 4
4. ✅ No WILSON_CONFIG
5. ✅ Real status/health/PID for wilson
6. ✅ restart/update/logs wilson work
7. ✅ Unified bash update function
8. ✅ All tests pass (44 tests, 150 expect() calls)