### PR TITLE
feat: add config command to wilson CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import {
 import { getConfigDir } from "@shetty4l/core/config";
 import { createDaemonManager } from "@shetty4l/core/daemon";
 import { join } from "path";
+import { loadConfig } from "./config";
 import { cmdServe } from "./serve";
 import { VERSION } from "./version";
 
@@ -23,6 +24,7 @@ Usage:
   wilson restart        Restart the Wilson daemon
   wilson health         Check Wilson health endpoint
   wilson logs [n]       Show last n Wilson daemon log lines (default: 20)
+  wilson config         Show current configuration
   wilson version        Show version
 
 Options:
@@ -61,6 +63,47 @@ const cmdLogs = createLogsCommand({
   emptyMessage: "No Wilson daemon logs found.",
 });
 
+export function cmdConfig(_args: string[], json: boolean): number {
+  const result = loadConfig();
+  if (!result.ok) {
+    console.error(`wilson: ${result.error}`);
+    return 1;
+  }
+  const config = result.value;
+
+  if (json) {
+    // Mask sensitive fields in JSON output
+    const masked = {
+      ...config,
+      cortex: { ...config.cortex, apiKey: config.cortex.apiKey ? "***" : "" },
+    };
+    console.log(JSON.stringify(masked, null, 2));
+    return 0;
+  }
+
+  console.log("");
+  console.log(`Host:                     ${config.host}`);
+  console.log(`Port:                     ${config.port}`);
+  console.log(`Cortex URL:               ${config.cortex.url}`);
+  console.log(
+    `Cortex API key:           ${config.cortex.apiKey ? "***" : "(not set)"}`,
+  );
+  console.log("");
+  console.log("Calendar channel:");
+  console.log(`  Enabled:                ${config.channels.calendar.enabled}`);
+  console.log(
+    `  Poll interval:          ${config.channels.calendar.pollIntervalSeconds}s`,
+  );
+  console.log(
+    `  Look-ahead:             ${config.channels.calendar.lookAheadDays} days`,
+  );
+  console.log(
+    `  Extended look-ahead:    ${config.channels.calendar.extendedLookAheadDays} days`,
+  );
+  console.log("");
+  return 0;
+}
+
 // Only run when executed directly, not when imported by tests
 const isDirectRun =
   import.meta.path === Bun.main || process.argv[1]?.endsWith("cli.ts");
@@ -77,6 +120,7 @@ if (isDirectRun) {
       restart: daemonCmds.restart,
       health: cmdHealth,
       logs: cmdLogs,
+      config: cmdConfig,
     },
   });
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, jest, test } from "bun:test";
 import { parseArgs } from "@shetty4l/core/cli";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { cmdConfig } from "../src/cli";
 
 describe("parseArgs", () => {
   test("extracts command and args", () => {
@@ -39,5 +43,84 @@ describe("parseArgs", () => {
     const result = parseArgs(["unknown-cmd", "arg1"]);
     expect(result.command).toBe("unknown-cmd");
     expect(result.args).toEqual(["arg1"]);
+  });
+});
+
+// --- cmdConfig ---
+
+describe("cmdConfig", () => {
+  const TMP = join(tmpdir(), `wilson-cli-config-test-${process.pid}`);
+  const CONFIG_DIR = join(TMP, "wilson");
+  const CONFIG_PATH = join(CONFIG_DIR, "config.json");
+
+  beforeEach(() => {
+    mkdirSync(CONFIG_DIR, { recursive: true });
+    process.env.XDG_CONFIG_HOME = TMP;
+  });
+
+  afterEach(() => {
+    rmSync(TMP, { recursive: true, force: true });
+    delete process.env.XDG_CONFIG_HOME;
+  });
+
+  test("returns 1 when config is invalid", () => {
+    // No config file → missing apiKey → error
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const code = cmdConfig([], false);
+    expect(code).toBe(1);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  test("prints human-readable config", () => {
+    writeFileSync(
+      CONFIG_PATH,
+      JSON.stringify({
+        port: 9999,
+        cortex: { url: "http://example.com", apiKey: "secret-key" },
+        channels: { calendar: { enabled: true } },
+      }),
+    );
+
+    const lines: string[] = [];
+    const spy = jest
+      .spyOn(console, "log")
+      .mockImplementation((msg: string) => lines.push(msg));
+
+    const code = cmdConfig([], false);
+    expect(code).toBe(0);
+
+    const output = lines.join("\n");
+    expect(output).toContain("9999");
+    expect(output).toContain("http://example.com");
+    expect(output).toContain("***"); // apiKey masked
+    expect(output).not.toContain("secret-key");
+    expect(output).toContain("true"); // calendar enabled
+
+    spy.mockRestore();
+  });
+
+  test("prints JSON with --json flag", () => {
+    writeFileSync(
+      CONFIG_PATH,
+      JSON.stringify({
+        cortex: { url: "http://example.com", apiKey: "secret-key" },
+      }),
+    );
+
+    const lines: string[] = [];
+    const spy = jest
+      .spyOn(console, "log")
+      .mockImplementation((msg: string) => lines.push(msg));
+
+    const code = cmdConfig([], true);
+    expect(code).toBe(0);
+
+    const parsed = JSON.parse(lines.join(""));
+    expect(parsed.cortex.apiKey).toBe("***"); // masked in JSON too
+    expect(parsed.cortex.url).toBe("http://example.com");
+    expect(parsed.port).toBe(7748); // default
+
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- Adds `wilson config` command matching the pattern from cortex/engram/synapse
- Displays host, port, cortex config, and calendar channel settings
- Masks `cortex.apiKey` in both human-readable and `--json` output
- 3 new tests (error case, human output, JSON output)