### PR TITLE
fix: dashboard 500 errors and update exit code issue

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -76,8 +76,7 @@ export async function installUpdate(
   token: string | null,
 ): Promise<Result<void, string>> {
   const env: Record<string, string> = {
-    PATH: process.env.PATH ?? "",
-    HOME: process.env.HOME ?? homedir(),
+    ...process.env,
     SKIP_LAUNCHAGENT_RELOAD: "1",
   };
   if (token) {
@@ -88,8 +87,8 @@ export async function installUpdate(
 
   try {
     const proc = Bun.spawn(["bash", "-c", installCmd], {
-      stdout: "pipe",
-      stderr: "pipe",
+      stdout: "inherit",
+      stderr: "inherit",
       env,
     });
 
@@ -109,10 +108,7 @@ export async function installUpdate(
     }
 
     if (result !== 0) {
-      const stderr = proc.stderr ? await new Response(proc.stderr).text() : "";
-      return err(
-        `install failed for ${svc.name} (exit ${result})${stderr ? `: ${stderr.trim()}` : ""}`,
-      );
+      return err(`install failed for ${svc.name} (exit ${result})`);
     }
 
     return ok(undefined);


### PR DESCRIPTION
## Summary

- **Dashboard 500 fix**: `serveDashboardFile()` now detects directories and serves `index.html` from them. Previously, paths like `/dashboard/health` tried to serve the directory itself, causing Bun's "MacOS does not support sending non-regular files" error.

- **Update exit code fix**: `installUpdate()` now inherits full `process.env` instead of a minimal set (`PATH`, `HOME` only). Also changed `stdout/stderr: "pipe"` to `"inherit"` to prevent buffer deadlock when install script produces verbose output (e.g., `astro build`).

## Changes

| File | Change |
|------|--------|
| `src/serve.ts` | Add `statSync` import, detect directories, serve their `index.html` |
| `src/update.ts` | Spread `process.env`, use `stdout/stderr: "inherit"` |

## Testing

- All 134 tests pass
- TypeScript compiles
- Lint passes