### PR TITLE
fix: install script grep pattern for Tailscale JSON

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -154,7 +154,8 @@ print_status() {
   local tailscale_bin="/Applications/Tailscale.app/Contents/MacOS/Tailscale"
   if [ -x "$tailscale_bin" ]; then
     local ts_hostname
-    ts_hostname=$("$tailscale_bin" status --json 2>/dev/null | grep -o '"DNSName":"[^"]*"' | head -1 | cut -d'"' -f4 | sed 's/\.$//')
+    # Note: grep pattern allows optional space after colon to handle JSON formatting variations
+    ts_hostname=$("$tailscale_bin" status --json 2>/dev/null | grep -o '"DNSName": *"[^"]*"' | head -1 | cut -d'"' -f4 | sed 's/\.$//' || true)
     if [ -n "$ts_hostname" ]; then
       echo "    Tailscale:  https://${ts_hostname}:${WILSON_HTTPS_PORT}/dashboard/"
     fi


### PR DESCRIPTION
## Problem

The supervisor was failing to restart Wilson after installing updates, leaving the old version running while `current-version` was updated. This caused the supervisor to think Wilson was "up to date" on subsequent cycles.

## Root Cause

In `print_status()`, the grep pattern for extracting DNSName from Tailscale's JSON output didn't account for the space after the colon:

```bash
# Before (broken) - expects no space
grep -o '"DNSName":"[^"]*"'

# Tailscale outputs (with space)
"DNSName": "hostname.tailnet.ts.net."
```

Under `set -o pipefail`, when grep finds no matches (exit 1), the pipeline fails. Under `set -e`, this causes the script to exit immediately with code 1 — even though the installation completed successfully.

The supervisor's `installUpdate()` saw exit code 1 and returned an error, so `restartService()` was never called.

## Fix

- Allow optional space after colon: `"DNSName": *"[^"]*"`
- Add `|| true` to prevent pipeline failure when grep finds no match

## Testing

Verified on mac-mini that the fixed pattern correctly extracts the hostname:
```
ts_hostname=suyashs-mac-mini.taildd10d7.ts.net
```