### PR TITLE
fix: SSE crash and connection timeout causing Wilson restart loop

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "wilson",
       "dependencies": {
-        "@shetty4l/core": "^0.1.30",
+        "@shetty4l/core": "^0.1.33",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.2",
@@ -73,7 +73,7 @@
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.49.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VteIelt78kwzSglOozaQcs6BCS4Lk0j+QA+hGV0W8UeyaqQ3XpbZRhDU55NW1PPvCy1tg4VXsTlEaPovqto7nQ=="],
 
-    "@shetty4l/core": ["@shetty4l/core@0.1.30", "", { "bin": { "version-bump": "bin/version-bump.js" } }, "sha512-Q0Po5lEHo7OlG0J+7mPYSoZmqvNvZr4dxnexrLXx/RZI/JnQcvBl4J7mE0luFZWdj3wsvZyDjWyMARMl6IiokA=="],
+    "@shetty4l/core": ["@shetty4l/core@0.1.33", "", { "bin": { "version-bump": "bin/version-bump.js" } }, "sha512-k7/+4gULGXDOdnqLAFU7CJbCCUYP81xByewEtuKY27r6fj+uE3zvd7MQJ5R6LHQ0XmAkmMKRp/yrVXOHu4COyQ=="],
 
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepare": "[ -d .git ] && husky || true"
   },
   "dependencies": {
-    "@shetty4l/core": "^0.1.30"
+    "@shetty4l/core": "^0.1.33"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.2",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -96,6 +96,7 @@ export async function cmdServe(): Promise<void> {
     port: config.port,
     host: config.host,
     version: VERSION,
+    idleTimeout: 120, // 2 minutes - needed for SSE long-lived connections
     onRequest: async (req: Request) => {
       const url = new URL(req.url);
 


### PR DESCRIPTION
## Summary

Fixes critical bug causing Wilson to crash and restart every ~30 seconds when the logs page is open.

## Root Cause

1. **SSE cancel() bug**: The `ReadableStream.cancel()` callback receives `reason` as its parameter, not `controller`. Our code was trying to access `controller._pollInterval` which was `undefined`, causing `TypeError`.

2. **Bun idle timeout**: Bun's default `idleTimeout` is 10 seconds, but our heartbeat was 15 seconds. The connection would be killed before the heartbeat fired, triggering the buggy `cancel()` callback.

## Changes

| File | Change |
|------|--------|
| `src/api/logs.ts` | Store intervals in closure variables instead of on controller |
| `src/api/logs.ts` | Reduce heartbeat from 15s → 5s |
| `src/serve.ts` | Add `idleTimeout: 120` (2 minutes) for SSE connections |
| `package.json` | Bump `@shetty4l/core` to 0.1.33 for `idleTimeout` support |

## Error Fixed

```
TypeError: undefined is not an object (evaluating 'ctrl._pollInterval')
  at cancel (/Users/suyash/srv/wilson/v0.2.11/src/api/logs.ts:182:11)
```

## Testing

- All 134 tests pass
- TypeScript compiles
- Lint passes