### PR TITLE
feat: update stats types and dashboard for 24h window

### DIFF
--- a/dashboard/src/pages/stats.astro
+++ b/dashboard/src/pages/stats.astro
@@ -239,10 +239,10 @@ try {
         | undefined;
       const operations = s.operations as
         | {
-            recall_1h: number;
-            remember_1h: number;
-            recall_hit_rate_1h: number;
-            recall_fallback_rate_1h: number;
+            recall_24h: number;
+            remember_24h: number;
+            recall_hit_rate_24h: number;
+            recall_fallback_rate_24h: number;
           }
         | undefined;
       const latency = s.latency as
@@ -265,22 +265,22 @@ try {
             </div>
           </div>
           <div>
-            <div class="font-mono text-xs text-text-muted uppercase tracking-wider mb-2">Operations (1h)</div>
+            <div class="font-mono text-xs text-text-muted uppercase tracking-wider mb-2">Operations (24h)</div>
             <div class="grid grid-cols-2 gap-3">
               <div>
-                <div class="font-mono text-lg text-text">${formatNumber(operations?.recall_1h)}</div>
+                <div class="font-mono text-lg text-text">${formatNumber(operations?.recall_24h)}</div>
                 <div class="font-mono text-xs text-text-muted">Recalls</div>
               </div>
               <div>
-                <div class="font-mono text-lg text-text">${formatNumber(operations?.remember_1h)}</div>
+                <div class="font-mono text-lg text-text">${formatNumber(operations?.remember_24h)}</div>
                 <div class="font-mono text-xs text-text-muted">Remembers</div>
               </div>
               <div>
-                <div class="font-mono text-lg text-text">${formatPercent(operations?.recall_hit_rate_1h)}</div>
+                <div class="font-mono text-lg text-text">${formatPercent(operations?.recall_hit_rate_24h)}</div>
                 <div class="font-mono text-xs text-text-muted">Hit Rate</div>
               </div>
               <div>
-                <div class="font-mono text-lg text-text">${formatPercent(operations?.recall_fallback_rate_1h)}</div>
+                <div class="font-mono text-lg text-text">${formatPercent(operations?.recall_fallback_rate_24h)}</div>
                 <div class="font-mono text-xs text-text-muted">Fallback Rate</div>
               </div>
             </div>
@@ -310,15 +310,15 @@ try {
         | undefined;
       const requests = s.requests as
         | {
-            total_1h: number;
-            errors_1h: number;
+            total_24h: number;
+            errors_24h: number;
             by_provider: Record<string, number>;
           }
         | undefined;
       const latency = s.latency as
         | { p50_ms: number; p95_ms: number; p99_ms: number }
         | undefined;
-      const fallbacks = s.fallbacks as { count_1h: number } | undefined;
+      const fallbacks = s.fallbacks as { count_24h: number } | undefined;
       const providers = s.providers as
         | Array<{
             name: string;
@@ -364,18 +364,18 @@ try {
             </div>
           </div>
           <div>
-            <div class="font-mono text-xs text-text-muted uppercase tracking-wider mb-2">Requests (1h)</div>
+            <div class="font-mono text-xs text-text-muted uppercase tracking-wider mb-2">Requests (24h)</div>
             <div class="grid grid-cols-3 gap-3">
               <div>
-                <div class="font-mono text-lg text-text">${formatNumber(requests?.total_1h)}</div>
+                <div class="font-mono text-lg text-text">${formatNumber(requests?.total_24h)}</div>
                 <div class="font-mono text-xs text-text-muted">Total</div>
               </div>
               <div>
-                <div class="font-mono text-lg text-red-nerv">${formatNumber(requests?.errors_1h)}</div>
+                <div class="font-mono text-lg text-red-nerv">${formatNumber(requests?.errors_24h)}</div>
                 <div class="font-mono text-xs text-text-muted">Errors</div>
               </div>
               <div>
-                <div class="font-mono text-lg text-orange-nerv">${formatNumber(fallbacks?.count_1h)}</div>
+                <div class="font-mono text-lg text-orange-nerv">${formatNumber(fallbacks?.count_24h)}</div>
                 <div class="font-mono text-xs text-text-muted">Fallbacks</div>
               </div>
             </div>
@@ -408,12 +408,12 @@ try {
         | {
             pending: number;
             processing: number;
-            done_1h: number;
-            failed_1h: number;
+            done_24h: number;
+            failed_24h: number;
           }
         | undefined;
       const outbox = s.outbox as
-        | { pending: number; delivered_1h: number; dead_total: number }
+        | { pending: number; delivered_24h: number; dead_total: number }
         | undefined;
       const receptors = s.receptors as
         | {
@@ -440,12 +440,12 @@ try {
                 <div class="font-mono text-xs text-text-muted">Processing</div>
               </div>
               <div>
-                <div class="font-mono text-lg text-green-nerv">${formatNumber(inbox?.done_1h)}</div>
-                <div class="font-mono text-xs text-text-muted">Done (1h)</div>
+                <div class="font-mono text-lg text-green-nerv">${formatNumber(inbox?.done_24h)}</div>
+                <div class="font-mono text-xs text-text-muted">Done (24h)</div>
               </div>
               <div>
-                <div class="font-mono text-lg text-red-nerv">${formatNumber(inbox?.failed_1h)}</div>
-                <div class="font-mono text-xs text-text-muted">Failed (1h)</div>
+                <div class="font-mono text-lg text-red-nerv">${formatNumber(inbox?.failed_24h)}</div>
+                <div class="font-mono text-xs text-text-muted">Failed (24h)</div>
               </div>
             </div>
           </div>
@@ -457,8 +457,8 @@ try {
                 <div class="font-mono text-xs text-text-muted">Pending</div>
               </div>
               <div>
-                <div class="font-mono text-lg text-green-nerv">${formatNumber(outbox?.delivered_1h)}</div>
-                <div class="font-mono text-xs text-text-muted">Delivered (1h)</div>
+                <div class="font-mono text-lg text-green-nerv">${formatNumber(outbox?.delivered_24h)}</div>
+                <div class="font-mono text-xs text-text-muted">Delivered (24h)</div>
               </div>
               <div>
                 <div class="font-mono text-lg text-red-nerv">${formatNumber(outbox?.dead_total)}</div>

--- a/src/api/indicators.ts
+++ b/src/api/indicators.ts
@@ -93,7 +93,7 @@ function computeTriage(stats: ServiceStats): Indicator {
 
   const inbox = stats.cortex.inbox;
   const pending = inbox.pending;
-  const failed = inbox.failed_1h;
+  const failed = inbox.failed_24h;
   const processing = inbox.processing;
 
   // Red: pending > 10 OR failed > 3 OR processing > 1
@@ -124,7 +124,7 @@ function computeTriage(stats: ServiceStats): Indicator {
     name,
     status: "green",
     label: "Clear",
-    detail: `${pending} pending, ${inbox.done_1h} done/1h`,
+    detail: `${pending} pending, ${inbox.done_24h} done/1h`,
   };
 }
 
@@ -143,12 +143,12 @@ function computeReasoning(stats: ServiceStats): Indicator {
   }
 
   const p50Seconds = msToSeconds(stats.cortex.processing.p50_ms);
-  const errors = stats.cortex.inbox.failed_1h;
+  const errors = stats.cortex.inbox.failed_24h;
 
   // Calculate synapse error rate (LLM errors impact reasoning)
   const synapseErrorRate =
-    stats.synapse && stats.synapse.requests.total_1h > 0
-      ? stats.synapse.requests.errors_1h / stats.synapse.requests.total_1h
+    stats.synapse && stats.synapse.requests.total_24h > 0
+      ? stats.synapse.requests.errors_24h / stats.synapse.requests.total_24h
       : 0;
 
   // Get synapse latency for context in detail message
@@ -287,7 +287,7 @@ function computeExpression(stats: ServiceStats): Indicator {
       name,
       status: "red",
       label: "Backlog",
-      detail: `${pending} pending, ${outbox.delivered_1h} delivered/1h`,
+      detail: `${pending} pending, ${outbox.delivered_24h} delivered/1h`,
     };
   }
 
@@ -298,7 +298,7 @@ function computeExpression(stats: ServiceStats): Indicator {
       name,
       status: "yellow",
       label: "Queued",
-      detail: `${pending} pending, ${outbox.delivered_1h} delivered/1h`,
+      detail: `${pending} pending, ${outbox.delivered_24h} delivered/1h`,
     };
   }
 
@@ -308,7 +308,7 @@ function computeExpression(stats: ServiceStats): Indicator {
     name,
     status: "green",
     label: "Clear",
-    detail: `${pending} pending, ${outbox.delivered_1h} delivered/1h`,
+    detail: `${pending} pending, ${outbox.delivered_24h} delivered/1h`,
   };
 }
 
@@ -337,7 +337,7 @@ function computeModels(stats: ServiceStats): Indicator {
   // Calculate error rate from requests
   const requests = stats.synapse.requests;
   const errorRate =
-    requests.total_1h > 0 ? requests.errors_1h / requests.total_1h : 0;
+    requests.total_24h > 0 ? requests.errors_24h / requests.total_24h : 0;
   const errorPct = (errorRate * 100).toFixed(0);
 
   // Red: all down
@@ -358,7 +358,7 @@ function computeModels(stats: ServiceStats): Indicator {
       name,
       status: "red",
       label: "High Errors",
-      detail: `${errorPct}% error rate (${requests.errors_1h}/${requests.total_1h})`,
+      detail: `${errorPct}% error rate (${requests.errors_24h}/${requests.total_24h})`,
     };
   }
 
@@ -379,7 +379,7 @@ function computeModels(stats: ServiceStats): Indicator {
       name,
       status: "yellow",
       label: "Degraded",
-      detail: `${errorPct}% error rate (${requests.errors_1h}/${requests.total_1h})`,
+      detail: `${errorPct}% error rate (${requests.errors_24h}/${requests.total_24h})`,
     };
   }
 

--- a/src/api/stats.ts
+++ b/src/api/stats.ts
@@ -10,10 +10,10 @@ export interface EngramStats {
     with_embedding_pct: number;
   };
   operations: {
-    recall_1h: number;
-    remember_1h: number;
-    recall_hit_rate_1h: number;
-    recall_fallback_rate_1h: number;
+    recall_24h: number;
+    remember_24h: number;
+    recall_hit_rate_24h: number;
+    recall_fallback_rate_24h: number;
   };
   latency: {
     recall_p50_ms: number;
@@ -37,8 +37,8 @@ export interface SynapseStats {
     oldest_entry_at: string | null;
   };
   requests: {
-    total_1h: number;
-    errors_1h: number;
+    total_24h: number;
+    errors_24h: number;
     by_provider: Record<string, number>;
   };
   latency: {
@@ -47,7 +47,7 @@ export interface SynapseStats {
     p99_ms: number;
   };
   fallbacks: {
-    count_1h: number;
+    count_24h: number;
   };
   providers: SynapseProvider[];
 }
@@ -58,12 +58,12 @@ export interface CortexStats {
   inbox: {
     pending: number;
     processing: number;
-    done_1h: number;
-    failed_1h: number;
+    done_24h: number;
+    failed_24h: number;
   };
   outbox: {
     pending: number;
-    delivered_1h: number;
+    delivered_24h: number;
     dead_total: number;
   };
   receptors: {

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -18,26 +18,26 @@ function makeFullStats(overrides?: Partial<ServiceStats>): ServiceStats {
     engram: {
       memories: { total: 100, with_embedding_pct: 100 },
       operations: {
-        recall_1h: 50,
-        remember_1h: 10,
-        recall_hit_rate_1h: 0.9,
-        recall_fallback_rate_1h: 0.1,
+        recall_24h: 50,
+        remember_24h: 10,
+        recall_hit_rate_24h: 0.9,
+        recall_fallback_rate_24h: 0.1,
       },
       latency: { recall_p50_ms: 100, recall_p95_ms: 200, recall_p99_ms: 300 },
     },
     synapse: {
       buffer: { capacity: 100, size: 10, oldest_entry_at: null },
-      requests: { total_1h: 100, errors_1h: 0, by_provider: {} },
+      requests: { total_24h: 100, errors_24h: 0, by_provider: {} },
       latency: { p50_ms: 500, p95_ms: 1000, p99_ms: 2000 },
-      fallbacks: { count_1h: 0 },
+      fallbacks: { count_24h: 0 },
       providers: [
         { name: "openai", healthy: true, consecutiveFailures: 0 },
         { name: "anthropic", healthy: true, consecutiveFailures: 0 },
       ],
     },
     cortex: {
-      inbox: { pending: 0, processing: 0, done_1h: 10, failed_1h: 0 },
-      outbox: { pending: 0, delivered_1h: 5, dead_total: 0 },
+      inbox: { pending: 0, processing: 0, done_24h: 10, failed_24h: 0 },
+      outbox: { pending: 0, delivered_24h: 5, dead_total: 0 },
       receptors: {
         calendar_last_sync_at: new Date().toISOString(),
         calendar_buffer_pending: 0,
@@ -189,7 +189,7 @@ describe("computeIndicators", () => {
       const stats = makeFullStats({
         cortex: {
           ...makeFullStats().cortex!,
-          inbox: { pending: 5, processing: 0, done_1h: 10, failed_1h: 0 },
+          inbox: { pending: 5, processing: 0, done_24h: 10, failed_24h: 0 },
         },
       });
       const indicators = computeIndicators(stats);
@@ -203,7 +203,7 @@ describe("computeIndicators", () => {
       const stats = makeFullStats({
         cortex: {
           ...makeFullStats().cortex!,
-          inbox: { pending: 0, processing: 0, done_1h: 10, failed_1h: 2 },
+          inbox: { pending: 0, processing: 0, done_24h: 10, failed_24h: 2 },
         },
       });
       const indicators = computeIndicators(stats);
@@ -216,7 +216,7 @@ describe("computeIndicators", () => {
       const stats = makeFullStats({
         cortex: {
           ...makeFullStats().cortex!,
-          inbox: { pending: 15, processing: 0, done_1h: 10, failed_1h: 0 },
+          inbox: { pending: 15, processing: 0, done_24h: 10, failed_24h: 0 },
         },
       });
       const indicators = computeIndicators(stats);
@@ -230,7 +230,7 @@ describe("computeIndicators", () => {
       const stats = makeFullStats({
         cortex: {
           ...makeFullStats().cortex!,
-          inbox: { pending: 0, processing: 0, done_1h: 10, failed_1h: 5 },
+          inbox: { pending: 0, processing: 0, done_24h: 10, failed_24h: 5 },
         },
       });
       const indicators = computeIndicators(stats);
@@ -243,7 +243,7 @@ describe("computeIndicators", () => {
       const stats = makeFullStats({
         cortex: {
           ...makeFullStats().cortex!,
-          inbox: { pending: 0, processing: 3, done_1h: 10, failed_1h: 0 },
+          inbox: { pending: 0, processing: 3, done_24h: 10, failed_24h: 0 },
         },
       });
       const indicators = computeIndicators(stats);
@@ -281,7 +281,7 @@ describe("computeIndicators", () => {
       const stats = makeFullStats({
         cortex: {
           ...makeFullStats().cortex!,
-          inbox: { pending: 0, processing: 0, done_1h: 10, failed_1h: 3 },
+          inbox: { pending: 0, processing: 0, done_24h: 10, failed_24h: 3 },
         },
       });
       const indicators = computeIndicators(stats);
@@ -308,7 +308,7 @@ describe("computeIndicators", () => {
       const stats = makeFullStats({
         cortex: {
           ...makeFullStats().cortex!,
-          inbox: { pending: 0, processing: 0, done_1h: 10, failed_1h: 10 },
+          inbox: { pending: 0, processing: 0, done_24h: 10, failed_24h: 10 },
         },
       });
       const indicators = computeIndicators(stats);
@@ -323,11 +323,11 @@ describe("computeIndicators", () => {
         cortex: {
           ...makeFullStats().cortex!,
           processing: { p50_ms: 2000, p95_ms: 5000, p99_ms: 10000 },
-          inbox: { pending: 0, processing: 0, done_1h: 10, failed_1h: 0 },
+          inbox: { pending: 0, processing: 0, done_24h: 10, failed_24h: 0 },
         },
         synapse: {
           ...makeFullStats().synapse!,
-          requests: { total_1h: 100, errors_1h: 25, by_provider: {} },
+          requests: { total_24h: 100, errors_24h: 25, by_provider: {} },
         },
       });
       const indicators = computeIndicators(stats);
@@ -342,11 +342,11 @@ describe("computeIndicators", () => {
         cortex: {
           ...makeFullStats().cortex!,
           processing: { p50_ms: 2000, p95_ms: 5000, p99_ms: 10000 },
-          inbox: { pending: 0, processing: 0, done_1h: 10, failed_1h: 0 },
+          inbox: { pending: 0, processing: 0, done_24h: 10, failed_24h: 0 },
         },
         synapse: {
           ...makeFullStats().synapse!,
-          requests: { total_1h: 100, errors_1h: 10, by_provider: {} },
+          requests: { total_24h: 100, errors_24h: 10, by_provider: {} },
         },
       });
       const indicators = computeIndicators(stats);
@@ -443,7 +443,7 @@ describe("computeIndicators", () => {
       const stats = makeFullStats({
         cortex: {
           ...makeFullStats().cortex!,
-          outbox: { pending: 5, delivered_1h: 10, dead_total: 0 },
+          outbox: { pending: 5, delivered_24h: 10, dead_total: 0 },
         },
       });
       const indicators = computeIndicators(stats);
@@ -457,7 +457,7 @@ describe("computeIndicators", () => {
       const stats = makeFullStats({
         cortex: {
           ...makeFullStats().cortex!,
-          outbox: { pending: 15, delivered_1h: 10, dead_total: 0 },
+          outbox: { pending: 15, delivered_24h: 10, dead_total: 0 },
         },
       });
       const indicators = computeIndicators(stats);
@@ -471,7 +471,7 @@ describe("computeIndicators", () => {
       const stats = makeFullStats({
         cortex: {
           ...makeFullStats().cortex!,
-          outbox: { pending: 0, delivered_1h: 10, dead_total: 1 },
+          outbox: { pending: 0, delivered_24h: 10, dead_total: 1 },
         },
       });
       const indicators = computeIndicators(stats);
@@ -553,7 +553,7 @@ describe("computeIndicators", () => {
       const stats = makeFullStats({
         synapse: {
           ...makeFullStats().synapse!,
-          requests: { total_1h: 100, errors_1h: 25, by_provider: {} },
+          requests: { total_24h: 100, errors_24h: 25, by_provider: {} },
         },
       });
       const indicators = computeIndicators(stats);
@@ -568,7 +568,7 @@ describe("computeIndicators", () => {
       const stats = makeFullStats({
         synapse: {
           ...makeFullStats().synapse!,
-          requests: { total_1h: 100, errors_1h: 10, by_provider: {} },
+          requests: { total_24h: 100, errors_24h: 10, by_provider: {} },
         },
       });
       const indicators = computeIndicators(stats);
@@ -583,7 +583,7 @@ describe("computeIndicators", () => {
       const stats = makeFullStats({
         synapse: {
           ...makeFullStats().synapse!,
-          requests: { total_1h: 100, errors_1h: 3, by_provider: {} },
+          requests: { total_24h: 100, errors_24h: 3, by_provider: {} },
         },
       });
       const indicators = computeIndicators(stats);
@@ -597,7 +597,7 @@ describe("computeIndicators", () => {
       const stats = makeFullStats({
         synapse: {
           ...makeFullStats().synapse!,
-          requests: { total_1h: 0, errors_1h: 0, by_provider: {} },
+          requests: { total_24h: 0, errors_24h: 0, by_provider: {} },
         },
       });
       const indicators = computeIndicators(stats);
@@ -612,7 +612,7 @@ describe("computeIndicators", () => {
       const stats = makeFullStats({
         synapse: {
           ...makeFullStats().synapse!,
-          requests: { total_1h: 100, errors_1h: 30, by_provider: {} },
+          requests: { total_24h: 100, errors_24h: 30, by_provider: {} },
           providers: [
             { name: "openai", healthy: true, consecutiveFailures: 0 },
             { name: "anthropic", healthy: true, consecutiveFailures: 0 },
@@ -712,7 +712,7 @@ describe("computeIndicators", () => {
       const stats2 = makeFullStats({
         cortex: {
           ...makeFullStats().cortex!,
-          inbox: { pending: 2, processing: 0, done_1h: 10, failed_1h: 0 },
+          inbox: { pending: 2, processing: 0, done_24h: 10, failed_24h: 0 },
         },
       });
       expect(getIndicator(computeIndicators(stats2), "triage").status).toBe(
@@ -722,7 +722,7 @@ describe("computeIndicators", () => {
       const stats3 = makeFullStats({
         cortex: {
           ...makeFullStats().cortex!,
-          inbox: { pending: 3, processing: 0, done_1h: 10, failed_1h: 0 },
+          inbox: { pending: 3, processing: 0, done_24h: 10, failed_24h: 0 },
         },
       });
       expect(getIndicator(computeIndicators(stats3), "triage").status).toBe(
@@ -732,7 +732,7 @@ describe("computeIndicators", () => {
       const stats10 = makeFullStats({
         cortex: {
           ...makeFullStats().cortex!,
-          inbox: { pending: 10, processing: 0, done_1h: 10, failed_1h: 0 },
+          inbox: { pending: 10, processing: 0, done_24h: 10, failed_24h: 0 },
         },
       });
       expect(getIndicator(computeIndicators(stats10), "triage").status).toBe(
@@ -742,7 +742,7 @@ describe("computeIndicators", () => {
       const stats11 = makeFullStats({
         cortex: {
           ...makeFullStats().cortex!,
-          inbox: { pending: 11, processing: 0, done_1h: 10, failed_1h: 0 },
+          inbox: { pending: 11, processing: 0, done_24h: 10, failed_24h: 0 },
         },
       });
       expect(getIndicator(computeIndicators(stats11), "triage").status).toBe(
@@ -795,10 +795,10 @@ describe("computeIndicators", () => {
         engram: {
           memories: { total: 50, with_embedding_pct: 100 },
           operations: {
-            recall_1h: 10,
-            remember_1h: 5,
-            recall_hit_rate_1h: 0.8,
-            recall_fallback_rate_1h: 0.2,
+            recall_24h: 10,
+            remember_24h: 5,
+            recall_hit_rate_24h: 0.8,
+            recall_fallback_rate_24h: 0.2,
           },
           latency: {
             recall_p50_ms: 50,


### PR DESCRIPTION
## Summary
- Updated TypeScript interfaces: EngramStats, SynapseStats, CortexStats
- Changed all `_1h` field references to `_24h` in stats.ts types
- Updated dashboard stats.astro page to use new field names

## Why
The 1-hour window was too short for a low-activity system, resulting in mostly zero values on the dashboard. 24 hours provides meaningful aggregate data.

## Coordination
This is part of a coordinated change across all services:
- engram
- synapse
- cortex  
- wilson (this PR - types + dashboard)

**Deploy order:** engram → synapse → cortex → wilson (wilson must be last since it consumes the APIs)