### PR TITLE
feat: improve triage indicator and dashboard UX

### DIFF
--- a/dashboard/src/components/ServiceHealthRow.astro
+++ b/dashboard/src/components/ServiceHealthRow.astro
@@ -40,7 +40,7 @@ const hasUpdate = latestVersion && version && latestVersion !== version;
   </div>
 
   <!-- Version -->
-  <div class="font-mono text-sm text-text-muted hidden sm:block">
+  <div class="font-mono text-sm text-text-muted">
     {version ? `v${version}` : "—"}
   </div>
 

--- a/dashboard/src/pages/health.astro
+++ b/dashboard/src/pages/health.astro
@@ -162,7 +162,7 @@ try {
               <div class="font-mono text-xs text-text-muted">Port ${svc.port}</div>
             </div>
           </div>
-          <div class="font-mono text-sm text-text-muted hidden sm:block">
+          <div class="font-mono text-sm text-text-muted">
             ${svc.version ? `v${svc.version}` : "—"}
           </div>
           <div class="font-mono text-xs uppercase tracking-wide hidden md:block ${statusColor}">

--- a/dashboard/src/pages/index.astro
+++ b/dashboard/src/pages/index.astro
@@ -11,7 +11,7 @@ import Layout from "../layouts/Layout.astro";
       </h2>
       <button
         id="refresh-btn"
-        class="font-mono text-xs text-amber-nerv hover:text-orange-nerv transition-colors px-2 py-1 border border-nerv-border hover:border-amber-nerv rounded"
+        class="font-mono text-xs text-amber-nerv hover:text-orange-nerv transition-colors px-2 py-1 border border-nerv-border hover:border-amber-nerv rounded active:scale-95 active:opacity-70"
       >
         REFRESH
       </button>

--- a/dashboard/src/pages/stats.astro
+++ b/dashboard/src/pages/stats.astro
@@ -47,7 +47,7 @@ try {
       <div class="flex items-center gap-3">
         <span
           id="refresh-indicator"
-          class="font-mono text-xs text-text-muted hidden"
+          class="font-mono text-xs text-text-muted opacity-0 transition-opacity"
         >
           Refreshing...
         </span>
@@ -557,7 +557,7 @@ try {
   // Fetch stats data
   async function fetchStats(): Promise<ServiceStats | null> {
     const indicator = document.getElementById("refresh-indicator");
-    if (indicator) indicator.classList.remove("hidden");
+    if (indicator) indicator.classList.replace("opacity-0", "opacity-100");
 
     try {
       const res = await fetch("/api/stats");
@@ -574,7 +574,7 @@ try {
       console.error("Failed to fetch stats:", e);
       return null;
     } finally {
-      if (indicator) indicator.classList.add("hidden");
+      if (indicator) indicator.classList.replace("opacity-100", "opacity-0");
     }
   }
 

--- a/src/api/indicators.ts
+++ b/src/api/indicators.ts
@@ -91,40 +91,47 @@ function computeTriage(stats: ServiceStats): Indicator {
     };
   }
 
-  const inbox = stats.cortex.inbox;
-  const pending = inbox.pending;
-  const failed = inbox.failed_24h;
-  const processing = inbox.processing;
+  const receptors = stats.cortex.receptors;
+  const bufferPending = receptors.buffer_pending_total;
+  const thalamusHoursAgo = hoursAgo(receptors.thalamus_last_run_at);
 
-  // Red: pending > 10 OR failed > 3 OR processing > 1
-  if (pending > 10 || failed > 3 || processing > 1) {
+  // Helper to format thalamus last run
+  const formatLastRun = (): string => {
+    if (thalamusHoursAgo === Number.POSITIVE_INFINITY) return "never";
+    if (thalamusHoursAgo < 1)
+      return `${Math.round(thalamusHoursAgo * 60)}m ago`;
+    return `${Math.round(thalamusHoursAgo)}h ago`;
+  };
+
+  // Red: thalamus very stale (>13h) OR buffer > 50
+  if (thalamusHoursAgo > 13 || bufferPending > 50) {
     return {
       id,
       name,
       status: "red",
-      label: "Backlog",
-      detail: `${pending} pending, ${failed} failed, ${processing} processing`,
+      label: "Stale",
+      detail: `Last run ${formatLastRun()}, ${bufferPending} buffered`,
     };
   }
 
-  // Yellow: pending 3-10 OR failed 1-3
-  if (pending >= 3 || failed >= 1) {
+  // Yellow: thalamus stale (>7h) OR buffer > 10
+  if (thalamusHoursAgo > 7 || bufferPending > 10) {
     return {
       id,
       name,
       status: "yellow",
-      label: "Busy",
-      detail: `${pending} pending, ${failed} failed`,
+      label: "Delayed",
+      detail: `Last run ${formatLastRun()}, ${bufferPending} buffered`,
     };
   }
 
-  // Green: pending <= 2, failed 0
+  // Green: thalamus fresh (<=7h) AND buffer <= 10
   return {
     id,
     name,
     status: "green",
     label: "Clear",
-    detail: `${pending} pending, ${inbox.done_24h} done/1h`,
+    detail: `Last run ${formatLastRun()}, ${bufferPending} buffered`,
   };
 }
 

--- a/src/api/stats.ts
+++ b/src/api/stats.ts
@@ -70,6 +70,7 @@ export interface CortexStats {
     calendar_last_sync_at: string | null;
     calendar_buffer_pending: number;
     thalamus_last_run_at: string | null;
+    buffer_pending_total: number;
   };
   processing: {
     p50_ms: number;

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -42,6 +42,7 @@ function makeFullStats(overrides?: Partial<ServiceStats>): ServiceStats {
         calendar_last_sync_at: new Date().toISOString(),
         calendar_buffer_pending: 0,
         thalamus_last_run_at: new Date().toISOString(),
+        buffer_pending_total: 0,
       },
       processing: { p50_ms: 2000, p95_ms: 5000, p99_ms: 10000 },
     },
@@ -100,6 +101,7 @@ describe("computeIndicators", () => {
             calendar_last_sync_at: twoHoursAgo,
             calendar_buffer_pending: 5,
             thalamus_last_run_at: twoHoursAgo,
+            buffer_pending_total: 0,
           },
         },
       });
@@ -118,6 +120,7 @@ describe("computeIndicators", () => {
             calendar_last_sync_at: new Date().toISOString(),
             calendar_buffer_pending: 25,
             thalamus_last_run_at: new Date().toISOString(),
+            buffer_pending_total: 0,
           },
         },
       });
@@ -138,6 +141,7 @@ describe("computeIndicators", () => {
             calendar_last_sync_at: sevenHoursAgo,
             calendar_buffer_pending: 0,
             thalamus_last_run_at: sevenHoursAgo,
+            buffer_pending_total: 0,
           },
         },
       });
@@ -156,6 +160,7 @@ describe("computeIndicators", () => {
             calendar_last_sync_at: new Date().toISOString(),
             calendar_buffer_pending: 100,
             thalamus_last_run_at: new Date().toISOString(),
+            buffer_pending_total: 0,
           },
         },
       });
@@ -176,7 +181,7 @@ describe("computeIndicators", () => {
   });
 
   describe("triage indicator", () => {
-    test("green when pending <= 2 and failed 0", () => {
+    test("green when thalamus fresh (<=7h) and buffer <= 10", () => {
       const stats = makeFullStats();
       const indicators = computeIndicators(stats);
       const triage = getIndicator(indicators, "triage");
@@ -185,71 +190,127 @@ describe("computeIndicators", () => {
       expect(triage.label).toBe("Clear");
     });
 
-    test("yellow when pending 3-10", () => {
+    test("yellow when thalamus stale (7-13h)", () => {
+      const eightHoursAgo = new Date(
+        Date.now() - 8 * 60 * 60 * 1000,
+      ).toISOString();
       const stats = makeFullStats({
         cortex: {
           ...makeFullStats().cortex!,
-          inbox: { pending: 5, processing: 0, done_24h: 10, failed_24h: 0 },
+          receptors: {
+            calendar_last_sync_at: new Date().toISOString(),
+            calendar_buffer_pending: 0,
+            thalamus_last_run_at: eightHoursAgo,
+            buffer_pending_total: 5,
+          },
         },
       });
       const indicators = computeIndicators(stats);
       const triage = getIndicator(indicators, "triage");
 
       expect(triage.status).toBe("yellow");
-      expect(triage.label).toBe("Busy");
+      expect(triage.label).toBe("Delayed");
     });
 
-    test("yellow when failed 1-3", () => {
+    test("yellow when buffer 11-50", () => {
       const stats = makeFullStats({
         cortex: {
           ...makeFullStats().cortex!,
-          inbox: { pending: 0, processing: 0, done_24h: 10, failed_24h: 2 },
+          receptors: {
+            calendar_last_sync_at: new Date().toISOString(),
+            calendar_buffer_pending: 0,
+            thalamus_last_run_at: new Date().toISOString(),
+            buffer_pending_total: 25,
+          },
         },
       });
       const indicators = computeIndicators(stats);
       const triage = getIndicator(indicators, "triage");
 
       expect(triage.status).toBe("yellow");
+      expect(triage.label).toBe("Delayed");
     });
 
-    test("red when pending > 10", () => {
+    test("red when thalamus very stale (>13h)", () => {
+      const fourteenHoursAgo = new Date(
+        Date.now() - 14 * 60 * 60 * 1000,
+      ).toISOString();
       const stats = makeFullStats({
         cortex: {
           ...makeFullStats().cortex!,
-          inbox: { pending: 15, processing: 0, done_24h: 10, failed_24h: 0 },
+          receptors: {
+            calendar_last_sync_at: new Date().toISOString(),
+            calendar_buffer_pending: 0,
+            thalamus_last_run_at: fourteenHoursAgo,
+            buffer_pending_total: 0,
+          },
         },
       });
       const indicators = computeIndicators(stats);
       const triage = getIndicator(indicators, "triage");
 
       expect(triage.status).toBe("red");
-      expect(triage.label).toBe("Backlog");
+      expect(triage.label).toBe("Stale");
     });
 
-    test("red when failed > 3", () => {
+    test("red when buffer > 50", () => {
       const stats = makeFullStats({
         cortex: {
           ...makeFullStats().cortex!,
-          inbox: { pending: 0, processing: 0, done_24h: 10, failed_24h: 5 },
+          receptors: {
+            calendar_last_sync_at: new Date().toISOString(),
+            calendar_buffer_pending: 0,
+            thalamus_last_run_at: new Date().toISOString(),
+            buffer_pending_total: 60,
+          },
         },
       });
       const indicators = computeIndicators(stats);
       const triage = getIndicator(indicators, "triage");
 
       expect(triage.status).toBe("red");
+      expect(triage.label).toBe("Stale");
     });
 
-    test("red when processing > 1", () => {
+    test("red when thalamus_last_run_at is null (never run)", () => {
       const stats = makeFullStats({
         cortex: {
           ...makeFullStats().cortex!,
-          inbox: { pending: 0, processing: 3, done_24h: 10, failed_24h: 0 },
+          receptors: {
+            calendar_last_sync_at: new Date().toISOString(),
+            calendar_buffer_pending: 0,
+            thalamus_last_run_at: null,
+            buffer_pending_total: 0,
+          },
         },
       });
       const indicators = computeIndicators(stats);
       const triage = getIndicator(indicators, "triage");
 
       expect(triage.status).toBe("red");
+      expect(triage.detail).toContain("never");
+    });
+
+    test("detail shows last run time in minutes when < 1h", () => {
+      const thirtyMinutesAgo = new Date(
+        Date.now() - 30 * 60 * 1000,
+      ).toISOString();
+      const stats = makeFullStats({
+        cortex: {
+          ...makeFullStats().cortex!,
+          receptors: {
+            calendar_last_sync_at: new Date().toISOString(),
+            calendar_buffer_pending: 0,
+            thalamus_last_run_at: thirtyMinutesAgo,
+            buffer_pending_total: 0,
+          },
+        },
+      });
+      const indicators = computeIndicators(stats);
+      const triage = getIndicator(indicators, "triage");
+
+      expect(triage.status).toBe("green");
+      expect(triage.detail).toContain("30m ago");
     });
   });
 
@@ -707,47 +768,143 @@ describe("computeIndicators", () => {
   });
 
   describe("edge cases", () => {
-    test("handles exactly at threshold boundaries", () => {
-      // pending exactly 2 (green), pending exactly 3 (yellow), pending exactly 10 (yellow), pending exactly 11 (red)
-      const stats2 = makeFullStats({
-        cortex: {
-          ...makeFullStats().cortex!,
-          inbox: { pending: 2, processing: 0, done_24h: 10, failed_24h: 0 },
-        },
-      });
-      expect(getIndicator(computeIndicators(stats2), "triage").status).toBe(
-        "green",
-      );
-
-      const stats3 = makeFullStats({
-        cortex: {
-          ...makeFullStats().cortex!,
-          inbox: { pending: 3, processing: 0, done_24h: 10, failed_24h: 0 },
-        },
-      });
-      expect(getIndicator(computeIndicators(stats3), "triage").status).toBe(
-        "yellow",
-      );
-
+    test("triage: handles exactly at threshold boundaries", () => {
+      // buffer exactly 10 (green), buffer exactly 11 (yellow), buffer exactly 50 (yellow), buffer exactly 51 (red)
       const stats10 = makeFullStats({
         cortex: {
           ...makeFullStats().cortex!,
-          inbox: { pending: 10, processing: 0, done_24h: 10, failed_24h: 0 },
+          receptors: {
+            calendar_last_sync_at: new Date().toISOString(),
+            calendar_buffer_pending: 0,
+            thalamus_last_run_at: new Date().toISOString(),
+            buffer_pending_total: 10,
+          },
         },
       });
       expect(getIndicator(computeIndicators(stats10), "triage").status).toBe(
-        "yellow",
+        "green",
       );
 
       const stats11 = makeFullStats({
         cortex: {
           ...makeFullStats().cortex!,
-          inbox: { pending: 11, processing: 0, done_24h: 10, failed_24h: 0 },
+          receptors: {
+            calendar_last_sync_at: new Date().toISOString(),
+            calendar_buffer_pending: 0,
+            thalamus_last_run_at: new Date().toISOString(),
+            buffer_pending_total: 11,
+          },
         },
       });
       expect(getIndicator(computeIndicators(stats11), "triage").status).toBe(
+        "yellow",
+      );
+
+      const stats50 = makeFullStats({
+        cortex: {
+          ...makeFullStats().cortex!,
+          receptors: {
+            calendar_last_sync_at: new Date().toISOString(),
+            calendar_buffer_pending: 0,
+            thalamus_last_run_at: new Date().toISOString(),
+            buffer_pending_total: 50,
+          },
+        },
+      });
+      expect(getIndicator(computeIndicators(stats50), "triage").status).toBe(
+        "yellow",
+      );
+
+      const stats51 = makeFullStats({
+        cortex: {
+          ...makeFullStats().cortex!,
+          receptors: {
+            calendar_last_sync_at: new Date().toISOString(),
+            calendar_buffer_pending: 0,
+            thalamus_last_run_at: new Date().toISOString(),
+            buffer_pending_total: 51,
+          },
+        },
+      });
+      expect(getIndicator(computeIndicators(stats51), "triage").status).toBe(
         "red",
       );
+    });
+
+    test("triage: thalamus_last_run_at time thresholds", () => {
+      // 7h (green), 7h+1m (yellow), 13h (yellow), 13h+1m (red)
+      const sevenHours = new Date(
+        Date.now() - 7 * 60 * 60 * 1000,
+      ).toISOString();
+      const sevenHoursPlusOne = new Date(
+        Date.now() - (7 * 60 + 1) * 60 * 1000,
+      ).toISOString();
+      const thirteenHours = new Date(
+        Date.now() - 13 * 60 * 60 * 1000,
+      ).toISOString();
+      const thirteenHoursPlusOne = new Date(
+        Date.now() - (13 * 60 + 1) * 60 * 1000,
+      ).toISOString();
+
+      const stats7h = makeFullStats({
+        cortex: {
+          ...makeFullStats().cortex!,
+          receptors: {
+            calendar_last_sync_at: new Date().toISOString(),
+            calendar_buffer_pending: 0,
+            thalamus_last_run_at: sevenHours,
+            buffer_pending_total: 0,
+          },
+        },
+      });
+      expect(getIndicator(computeIndicators(stats7h), "triage").status).toBe(
+        "green",
+      );
+
+      const stats7hPlus = makeFullStats({
+        cortex: {
+          ...makeFullStats().cortex!,
+          receptors: {
+            calendar_last_sync_at: new Date().toISOString(),
+            calendar_buffer_pending: 0,
+            thalamus_last_run_at: sevenHoursPlusOne,
+            buffer_pending_total: 0,
+          },
+        },
+      });
+      expect(
+        getIndicator(computeIndicators(stats7hPlus), "triage").status,
+      ).toBe("yellow");
+
+      const stats13h = makeFullStats({
+        cortex: {
+          ...makeFullStats().cortex!,
+          receptors: {
+            calendar_last_sync_at: new Date().toISOString(),
+            calendar_buffer_pending: 0,
+            thalamus_last_run_at: thirteenHours,
+            buffer_pending_total: 0,
+          },
+        },
+      });
+      expect(getIndicator(computeIndicators(stats13h), "triage").status).toBe(
+        "yellow",
+      );
+
+      const stats13hPlus = makeFullStats({
+        cortex: {
+          ...makeFullStats().cortex!,
+          receptors: {
+            calendar_last_sync_at: new Date().toISOString(),
+            calendar_buffer_pending: 0,
+            thalamus_last_run_at: thirteenHoursPlusOne,
+            buffer_pending_total: 0,
+          },
+        },
+      });
+      expect(
+        getIndicator(computeIndicators(stats13hPlus), "triage").status,
+      ).toBe("red");
     });
 
     test("handles embedding exactly at 90% (yellow) and 89% (red)", () => {
@@ -780,6 +937,7 @@ describe("computeIndicators", () => {
             calendar_last_sync_at: null,
             calendar_buffer_pending: 0,
             thalamus_last_run_at: null,
+            buffer_pending_total: 0,
           },
         },
       });


### PR DESCRIPTION
## Summary
- Update Triage indicator to derive health from `buffer_pending_total` + `thalamus_last_run_at` (vs. old inbox-based logic)
- Fix dashboard UI issues: mobile version visibility, refresh indicator flicker, refresh button feedback

## Changes

### Triage Indicator Improvements
- **New thresholds** (now derived from thalamus state, not inbox queue):
  - Green: ≤7h since last run AND ≤10 pending buffers
  - Yellow: >7h since last run OR >10 pending buffers
  - Red: >13h since last run OR >50 pending buffers
- Add `buffer_pending_total` to `CortexStats.receptors` type

### Dashboard UX Fixes
- **Health page**: Show version on mobile (removed `hidden sm:block`)
- **Stats page**: Fix "Refreshing..." indicator flicker (use opacity transition)
- **Overview page**: Add `active:scale-95 active:opacity-70` to refresh button

## Testing
- 136 tests pass (373 expect() calls)
- Triage indicator tests rewritten for new buffer-based thresholds
- Dashboard builds successfully

## Dependencies
This PR depends on Cortex PR #87 being merged and deployed first, which exposes `buffer_pending_total` in `/stats`.