### PR TITLE
fix(dashboard): remove refresh indicator, fix stats header layout

### DIFF
--- a/dashboard/src/pages/health.astro
+++ b/dashboard/src/pages/health.astro
@@ -32,17 +32,9 @@ try {
       <h2 class="font-heading font-semibold text-lg text-text">
         Service Health
       </h2>
-      <div class="flex items-center gap-3">
-        <span
-          id="refresh-indicator"
-          class="font-mono text-xs text-text-muted hidden"
-        >
-          Refreshing...
-        </span>
-        <span id="last-update" class="font-mono text-xs text-text-muted">
-          —
-        </span>
-      </div>
+      <span id="last-update" class="font-mono text-xs text-text-muted">
+        —
+      </span>
     </div>
 
     <!-- Error State -->
@@ -184,9 +176,6 @@ try {
 
   // Fetch health data
   async function fetchHealth(): Promise<ServiceHealth[] | null> {
-    const indicator = document.getElementById("refresh-indicator");
-    if (indicator) indicator.classList.remove("hidden");
-
     try {
       const res = await fetch("/api/health");
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -201,8 +190,6 @@ try {
     } catch (e) {
       console.error("Failed to fetch health:", e);
       return null;
-    } finally {
-      if (indicator) indicator.classList.add("hidden");
     }
   }
 

--- a/dashboard/src/pages/stats.astro
+++ b/dashboard/src/pages/stats.astro
@@ -40,21 +40,13 @@ try {
 
 <Layout title="Stats | Wilson Dashboard" currentPage="stats">
   <div class="space-y-6">
-    <div class="flex items-center justify-between flex-wrap gap-4">
+    <div class="flex items-center justify-between">
       <h2 class="font-heading font-semibold text-lg text-text">
         System Statistics
       </h2>
-      <div class="flex items-center gap-3">
-        <span
-          id="refresh-indicator"
-          class="font-mono text-xs text-text-muted opacity-0 transition-opacity"
-        >
-          Refreshing...
-        </span>
-        <span id="last-update" class="font-mono text-xs text-text-muted">
-          —
-        </span>
-      </div>
+      <span id="last-update" class="font-mono text-xs text-text-muted">
+        —
+      </span>
     </div>
 
     <!-- Tab Navigation -->
@@ -556,9 +548,6 @@ try {
 
   // Fetch stats data
   async function fetchStats(): Promise<ServiceStats | null> {
-    const indicator = document.getElementById("refresh-indicator");
-    if (indicator) indicator.classList.replace("opacity-0", "opacity-100");
-
     try {
       const res = await fetch("/api/stats");
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -573,8 +562,6 @@ try {
     } catch (e) {
       console.error("Failed to fetch stats:", e);
       return null;
-    } finally {
-      if (indicator) indicator.classList.replace("opacity-100", "opacity-0");
     }
   }
 


### PR DESCRIPTION
## Summary
- Remove unnecessary "Refreshing..." indicator from stats and health pages
- Fix stats page header layout where timestamp wrapped to a second line

## Changes

### Stats page (`dashboard/src/pages/stats.astro`)
- Remove `flex-wrap gap-4` from header div (caused timestamp to wrap on smaller screens)
- Remove "Refreshing..." span and related JS logic
- Simplify to just title + timestamp on one line

### Health page (`dashboard/src/pages/health.astro`)
- Remove "Refreshing..." span and related JS logic
- Data still refreshes silently every 30s

## Why
The "Refreshing..." flash was unnecessary UI noise. The "Updated HH:MM:SS" timestamp already tells users when data was last fetched. Silent refresh is cleaner UX.